### PR TITLE
Use official multiple buildpacks support

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,0 @@
-https://github.com/miketheman/heroku-buildpack-datadog.git
-https://github.com/heroku/heroku-buildpack-ruby

--- a/app.json
+++ b/app.json
@@ -13,7 +13,10 @@
   },
   "buildpacks": [
     {
-      "url": "https://github.com/ddollar/heroku-buildpack-multi"
+      "url": "https://github.com/miketheman/heroku-buildpack-datadog.git"
+    },
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-ruby"
     }
   ]
 }


### PR DESCRIPTION
## WHY

[heroku-buildpack-multi](https://github.com/ddollar/heroku-buildpack-multi) is no longer maintained. Instead Heroku now supports multiple buildpacks for an App.
## WHAT

Drop heroku-buildpack-multi and write all buildpacks in app.json.
## REF
- [Using Multiple Buildpacks for an App | Heroku Dev Center](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app)
