### PR TITLE
Build binaries and Docker image on Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ vendor/
 
 /sendgrid2datadog
 /bin
+/dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      all_branches: true
-      # branch: master
+      branch: master
   - provider: script
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,8 @@ deploy:
     skip_cleanup: true
     script: make ci-docker-release
     on:
-      branch: master
+      all_branches: true
+      # branch: master
   - provider: script
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,37 @@
+sudo: required
+services:
+  - docker
+language: go
+go:
+  - '1.7'
+before_install:
+  - sudo add-apt-repository ppa:masterminds/glide -y
+  - sudo apt-get update -q
+  - sudo apt-get install glide -y
+  - mkdir -p $GOPATH/bin
+install:
+  - make deps
+script:
+  - make test
+before_deploy:
+  - GOOS=linux GOARCH=amd64 CGO_ENABLED=0 make
+  - make cross-build
+  - make dist
+deploy:
+  - provider: releases
+    skip_cleanup: true
+    api_key: $GITHUB_TOKEN
+    file_glob: true
+    file: 'dist/*.{tar.gz,zip}'
+    on:
+      tags: true
+  - provider: script
+    skip_cleanup: true
+    script: make ci-docker-release
+    on:
+      branch: master
+  - provider: script
+    skip_cleanup: true
+    script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
+    on:
+      tags: true

--- a/Makefile
+++ b/Makefile
@@ -53,12 +53,6 @@ ifeq ($(findstring ELF 64-bit LSB,$(shell file bin/$(NAME) 2> /dev/null)),)
 endif
 	docker build -t $(DOCKER_IMAGE) .
 
-.PHONY: docker-test
-docker-test:
-	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 $(MAKE)
-	$(MAKE) docker-build
-	docker run --rm $(DOCKER_IMAGE) version
-
 .PHONY: glide
 glide:
 ifeq ($(shell command -v glide 2> /dev/null),)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # SendGrid2Datadog
 
 [![Build Status](https://travis-ci.org/dtan4/sendgrid2datadog.svg?branch=master)](https://travis-ci.org/dtan4/sendgrid2datadog)
+[![Docker Repository on Quay](https://quay.io/repository/dtan4/sendgrid2datadog/status "Docker Repository on Quay")](https://quay.io/repository/dtan4/sendgrid2datadog)
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 Send SendGrid metrics to Datadog

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SendGrid2Datadog
 
-[![Dependency Status](https://gemnasium.com/badges/github.com/dtan4/sendgrid2datadog.svg)](https://gemnasium.com/github.com/dtan4/sendgrid2datadog)
+[![Build Status](https://travis-ci.org/dtan4/sendgrid2datadog.svg?branch=master)](https://travis-ci.org/dtan4/sendgrid2datadog)
 [![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
 
 Send SendGrid metrics to Datadog


### PR DESCRIPTION
## WHY

I want to prepare Docker image with the master build to deploy sendgrid2datadog to Kubernetes cluster.

## WHAT

Build binaries and Docker image on Travis CI.