### PR TITLE
Prepare Kubernetes files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     environment:
       - DOGSTATSD_HOST=dogstatsd
     ports:
-      - 9292:9292
+      - 8080:8080
   dogstatsd:
     image: datadog/docker-dd-agent:latest-dogstatsd
     environment:

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: sendgrid2datadog
+  namespace: sendgrid2datadog
+  labels:
+    name: sendgrid2datadog
+    role: web
+spec:
+  minReadySeconds: 30
+  strategy:
+    type: RollingUpdate
+  replicas: 1
+  template:
+    metadata:
+      name: sendgrid2datadog
+      labels:
+        name: sendgrid2datadog
+        role: web
+    spec:
+      containers:
+      - image: quay.io/dtan4/sendgrid2datadog:latest
+        name: sendgrid2datadog
+        ports:
+        - containerPort: 8080
+      - image: datadog/docker-dd-agent:latest-dogstatsd
+        name: dogstatsd
+        ports:
+        - containerPort: 8125
+        env:
+        - name: API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: dd-agent
+              key: api-key

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: sendgrid2datadog

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: sendgrid2datadog
+  namespace: sendgrid2datadog
+  labels:
+    name: sendgrid2datadog
+    role: web
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 8080
+  selector:
+    name: sendgrid2datadog
+    role: web
+  type: LoadBalancer


### PR DESCRIPTION
## WHY

I'd like to deploy SendGrid2Datadog to our Kubernetes cluster instead of Heroku.

## WHAT

Prepare files to deploy application to Kubernetes. It works fine.