### PR TITLE
Enable Basic Auth

### DIFF
--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -23,6 +23,17 @@ spec:
         name: sendgrid2datadog
         ports:
         - containerPort: 8080
+        env:
+        - name: BASIC_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: sendgrid2datadog
+              key: basic-auth-username
+        - name: BASIC_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sendgrid2datadog
+              key: basic-auth-password
       - image: datadog/docker-dd-agent:latest-dogstatsd
         name: dogstatsd
         ports:


### PR DESCRIPTION
## WHY

Webhook endpoint must be protected from unexpected external requests.

## WHAT

Set basic auth protection for `POST /webhook` endpoint. When both `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD` environment variables are given, basic auth will be enabled. Otherwise, basic auth will be disabled.