### PR TITLE
Build Docker image with commit tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,7 @@ deploy:
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=${TRAVIS_COMMIT::8} make ci-docker-release
     on:
-      all_branches: true
-      # branch: master
+      branch: master
   - provider: script
     skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,12 @@ deploy:
       branch: master
   - provider: script
     skip_cleanup: true
+    script: DOCKER_IMAGE_TAG=${TRAVIS_COMMIT::8} make ci-docker-release
+    on:
+      all_branches: true
+      # branch: master
+  - provider: script
+    skip_cleanup: true
     script: DOCKER_IMAGE_TAG=$TRAVIS_TAG make ci-docker-release
     on:
       tags: true


### PR DESCRIPTION
## WHY

Unique docker tags are required to deploy to Kubernetes continuously.

## WHAT

Build Docker image with commit tag in addition to `latest` tag.